### PR TITLE
Fix Increase Reserve Population causing an error while building a mod

### DIFF
--- a/modbuilder/plugins/increase_reserve_population.py
+++ b/modbuilder/plugins/increase_reserve_population.py
@@ -80,7 +80,10 @@ def update_reserve_population(root: RtpcNode, f_bytes: bytearray, multiply: floa
         result = _big_props(child.prop_table)          
         offsets_to_change.append(_big_props(child.prop_table))
        
-  reserve_values = reduce(lambda a, b: a + b, offsets_to_change)
+  reserve_values = []
+  if len(offsets_to_change) > 0:
+    reserve_values = reduce(lambda a, b: a + b, offsets_to_change)
+    
   try:
     for reserve_value in reserve_values:
       new_value = round(reserve_value.value * multiply)


### PR DESCRIPTION
Heyo, got this crash when I was building a mod with increase reserve population.

```
Traceback (most recent call last):
  File "modbuilder.py", line 4, in <module>
  File "modbuildermain.py", line 4, in main
  File "modbuilder\gui.py", line 270, in main
  File "modbuilder\mods.py", line 189, in apply_mod
  File "C:\Users\Pigeon\Desktop\modbuilder\modbuilder\plugins\increase_reserve_population.py", line 105, in process
    update_all_populations(mods.APP_DIR_PATH / "mod/dropzone/settings/hp_settings", multiply)
  File "C:\Users\Pigeon\Desktop\modbuilder\modbuilder\plugins\increase_reserve_population.py", line 100, in update_all_populations
    update_reserve_population(root, data, multiply)
  File "C:\Users\Pigeon\Desktop\modbuilder\modbuilder\plugins\increase_reserve_population.py", line 83, in update_reserve_population
    reserve_values = reduce(lambda a, b: a + b, offsets_to_change)
TypeError: reduce() of empty iterable with no initial value
```

I'm not exactly a keen python developer but this seemed like a simple fix. I could be an absolute moron and have not fixed this at all, but the crash has gone away for me. Hope this helps!